### PR TITLE
Synthetic Wounds Port

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1739,6 +1739,14 @@
 	if(!affected_mob.blood_volume)
 		return
 
+	// SKYRAT EDIT CHANGE BEGIN -- Adds check for owner_flags
+	var/owner_flags
+	if (iscarbon(affected_mob))
+		var/mob/living/carbon/carbon_mob = affected_mob
+		owner_flags = carbon_mob.dna.species.reagent_flags
+	if (!isnull(owner_flags) && !(owner_flags & PROCESS_ORGANIC))
+		return
+	// SKYRAT EDIT CHANGE END
 	if(SPT_PROB(7.5, seconds_per_tick))
 		affected_mob.losebreath += rand(2, 4)
 		affected_mob.adjustOxyLoss(rand(1, 3), updating_health = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)

--- a/modular_skyrat/modules/medical/code/wounds/synth/blunt/robotic_blunt.dm
+++ b/modular_skyrat/modules/medical/code/wounds/synth/blunt/robotic_blunt.dm
@@ -89,7 +89,8 @@
 	var/last_time_victim_moved = 0
 
 	processes = TRUE
-
+/// Whenever an oscillation is triggered by movement, we wait 4 seconds before trying to do another.
+	COOLDOWN_DECLARE(movement_stagger_cooldown)
 /datum/wound_pregen_data/blunt_metal
 	abstract = TRUE
 	required_limb_biostate = BIO_METAL
@@ -249,7 +250,7 @@
 	message += "!"
 	self_message += "! You might be able to avoid an aftershock by stopping and waiting..."
 
-	if (isnull(attack_direction))
+	if (isnull(attack_direction) && !isnull(attacking_item))
 		attack_direction = get_dir(victim, attacking_item)
 
 	if (!isnull(attack_direction) && prob(stagger_score * stagger_movement_chance_ratio))
@@ -359,9 +360,10 @@
 
 	overall_mult *= get_buckled_movement_consequence_mult(victim.buckled)
 
-	if (limb.body_zone == BODY_ZONE_CHEST)
+	if (limb.body_zone == BODY_ZONE_CHEST && COOLDOWN_FINISHED(src, movement_stagger_cooldown))
 		var/stagger_chance = chest_movement_stagger_chance * overall_mult
 		if (prob(stagger_chance))
+		    COOLDOWN_START(src, movement_stagger_cooldown, 4 SECONDS)
 			stagger(base_movement_stagger_score, shake_duration = base_stagger_movement_shake_duration, from_movement = TRUE, shift = movement_stagger_shift, knockdown_ratio = stagger_aftershock_knockdown_movement_ratio)
 
 	last_time_victim_moved = world.time

--- a/modular_skyrat/modules/medical/code/wounds/synth/blunt/robotic_blunt.dm
+++ b/modular_skyrat/modules/medical/code/wounds/synth/blunt/robotic_blunt.dm
@@ -363,7 +363,7 @@
 	if (limb.body_zone == BODY_ZONE_CHEST && COOLDOWN_FINISHED(src, movement_stagger_cooldown))
 		var/stagger_chance = chest_movement_stagger_chance * overall_mult
 		if (prob(stagger_chance))
-		    COOLDOWN_START(src, movement_stagger_cooldown, 4 SECONDS)
+			COOLDOWN_START(src, movement_stagger_cooldown, 4 SECONDS)
 			stagger(base_movement_stagger_score, shake_duration = base_stagger_movement_shake_duration, from_movement = TRUE, shift = movement_stagger_shift, knockdown_ratio = stagger_aftershock_knockdown_movement_ratio)
 
 	last_time_victim_moved = world.time

--- a/modular_skyrat/modules/medical/code/wounds/synth/blunt/robotic_blunt_T1.dm
+++ b/modular_skyrat/modules/medical/code/wounds/synth/blunt/robotic_blunt_T1.dm
@@ -43,7 +43,7 @@
 	var/delay_mult = 1
 
 	if (user == victim)
-		delay_mult *= 3
+		delay_mult *= 2
 
 	if (HAS_TRAIT(user, TRAIT_DIAGNOSTIC_HUD))
 		delay_mult *= 0.5
@@ -56,7 +56,7 @@
 	victim.visible_message(span_notice("[user] begins fastening the screws of [their_or_other] [limb.plaintext_zone]..."), \
 		span_notice("You begin fastening the screws of [your_or_other] [limb.plaintext_zone]..."))
 
-	if (!screwdriver_tool.use_tool(target = victim, user = user, delay = (10 SECONDS * delay_mult), volume = 50, extra_checks = CALLBACK(src, PROC_REF(still_exists))))
+	if (!screwdriver_tool.use_tool(target = victim, user = user, delay = (6 SECONDS * delay_mult), volume = 50, extra_checks = CALLBACK(src, PROC_REF(still_exists))))
 		return
 
 	victim.visible_message(span_green("[user] finishes fastening [their_or_other] [limb.plaintext_zone]!"), \

--- a/modular_skyrat/modules/medical/code/wounds/synth/blunt/robotic_blunt_T2.dm
+++ b/modular_skyrat/modules/medical/code/wounds/synth/blunt/robotic_blunt_T2.dm
@@ -32,7 +32,7 @@
 	chest_attacked_stagger_chance_ratio = 5
 	chest_attacked_stagger_mult = 3
 
-	chest_movement_stagger_chance = 3
+	chest_movement_stagger_chance = 2
 
 	stagger_aftershock_knockdown_ratio = 0.3
 	stagger_aftershock_knockdown_movement_ratio = 0.2

--- a/modular_skyrat/modules/medical/code/wounds/synth/blunt/robotic_blunt_T3.dm
+++ b/modular_skyrat/modules/medical/code/wounds/synth/blunt/robotic_blunt_T3.dm
@@ -38,7 +38,7 @@
 	status_effect_type = /datum/status_effect/wound/blunt/robotic/critical
 	treatable_tools = list(TOOL_WELDER, TOOL_CROWBAR)
 
-	base_movement_stagger_score = 55
+	base_movement_stagger_score = 50
 
 	base_aftershock_camera_shake_duration = 1.75 SECONDS
 	base_aftershock_camera_shake_strength = 1
@@ -46,7 +46,7 @@
 	chest_attacked_stagger_chance_ratio = 6.5
 	chest_attacked_stagger_mult = 4
 
-	chest_movement_stagger_chance = 14
+	chest_movement_stagger_chance = 8
 
 	aftershock_stopped_moving_score_mult = 0.3
 
@@ -117,7 +117,7 @@
 	if (HAS_TRAIT(src, TRAIT_WOUND_SCANNED))
 		delay_mult *= 0.75
 
-	if(!do_after(user, 8 SECONDS, target = victim, extra_checks = CALLBACK(src, PROC_REF(still_exists))))
+	if(!do_after(user, 4 SECONDS, target = victim, extra_checks = CALLBACK(src, PROC_REF(still_exists))))
 		return
 	mold_metal(user)
 	return TRUE
@@ -213,7 +213,7 @@
 	if (HAS_TRAIT(src, TRAIT_WOUND_SCANNED))
 		delay_mult *= 0.75
 
-	if (!welder.use_tool(target = victim, user = user, delay = 10 SECONDS * delay_mult, volume = 50, extra_checks = CALLBACK(src, PROC_REF(still_exists))))
+	if (!welder.use_tool(target = victim, user = user, delay = 7 SECONDS * delay_mult, volume = 50, extra_checks = CALLBACK(src, PROC_REF(still_exists))))
 		return TRUE
 
 	var/wound_path = /datum/wound/burn/robotic/overheat/severe
@@ -249,11 +249,11 @@
 	var/their_or_other = (user == victim ? "[user.p_their()]" : "[victim]'s")
 	var/your_or_other = (user == victim ? "your" : "[victim]'s")
 
-	var/base_time = 10 SECONDS
+	var/base_time = 7 SECONDS
 	var/delay_mult = 1
 	var/knows_wires = FALSE
 	if (victim == user)
-		delay_mult *= 3 // real slow
+		delay_mult *= 2
 	if (HAS_TRAIT(src, TRAIT_WOUND_SCANNED))
 		delay_mult *= 0.75
 	if (HAS_TRAIT(user, TRAIT_KNOW_ROBO_WIRES))
@@ -335,7 +335,7 @@
 
 	delay_mult /= treating_plunger.plunge_mod
 
-	if (!treating_plunger.use_tool(target = victim, user = user, delay = 8 SECONDS * delay_mult, volume = 50, extra_checks = CALLBACK(src, PROC_REF(still_exists))))
+	if (!treating_plunger.use_tool(target = victim, user = user, delay = 6 SECONDS * delay_mult, volume = 50, extra_checks = CALLBACK(src, PROC_REF(still_exists))))
 		return TRUE
 
 	var/success_chance = 80

--- a/modular_skyrat/modules/medical/code/wounds/synth/blunt/secures_internals.dm
+++ b/modular_skyrat/modules/medical/code/wounds/synth/blunt/secures_internals.dm
@@ -340,14 +340,14 @@
 
 	var/delay_mult = 1
 	if (victim == user)
-		delay_mult *= 0.5
+		delay_mult *= 1.5
 
 	if (HAS_TRAIT(src, TRAIT_WOUND_SCANNED))
 		delay_mult *= 0.75
 
 	user.visible_message(span_danger("[user] begins hastily applying [gel] to [victim]'s [limb.plaintext_zone]..."), span_warning("You begin hastily applying [gel] to [user == victim ? "your" : "[victim]'s"] [limb.plaintext_zone], disregarding the acidic effect it seems to have on the metal..."))
 
-	if (!do_after(user, (8 SECONDS * delay_mult), target = victim, extra_checks = CALLBACK(src, PROC_REF(still_exists))))
+	if (!do_after(user, (6 SECONDS * delay_mult), target = victim, extra_checks = CALLBACK(src, PROC_REF(still_exists))))
 		return TRUE
 
 	gel.use(1)

--- a/modular_skyrat/modules/medical/code/wounds/synth/medicine_reagents.dm
+++ b/modular_skyrat/modules/medical/code/wounds/synth/medicine_reagents.dm
@@ -1,0 +1,31 @@
+#define CLOT_RATE_INTENSITY_MULT 50
+
+/datum/reagent/medicine/coagulant
+	/// was_working, but for electrical damage
+	var/was_working_synth
+	process_flags = REAGENT_ORGANIC | REAGENT_SYNTHETIC
+
+/datum/reagent/medicine/coagulant/on_mob_end_metabolize(mob/living/affected_mob)
+	. = ..()
+
+	if (was_working_synth)
+		to_chat(affected_mob, span_warning("The chemicals sealing your faulty wires loses its effect!"))
+
+/datum/reagent/medicine/coagulant/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
+	. = ..()
+
+	var/datum/wound/electrical_damage/zappiest_wound
+
+	for (var/datum/wound/electrical_damage/electrical_wound in affected_mob.all_wounds)
+		if (electrical_wound.processing_shock_power_per_second_max > zappiest_wound?.processing_shock_power_per_second_max)
+			zappiest_wound = electrical_wound
+
+	if (zappiest_wound)
+		if (!was_working_synth)
+			to_chat(affected_mob, span_warning("Your damaged circuitry is encased in a insulative substance!"))
+			was_working_synth = TRUE
+		zappiest_wound.adjust_intensity(-clot_rate * CLOT_RATE_INTENSITY_MULT * seconds_per_tick)
+	else
+		was_working_synth = FALSE
+
+#undef CLOT_RATE_INTENSITY_MULT

--- a/modular_skyrat/modules/medical/code/wounds/synth/robotic_burns.dm
+++ b/modular_skyrat/modules/medical/code/wounds/synth/robotic_burns.dm
@@ -97,7 +97,7 @@
 
 	return ..()
 
-	/datum/wound/burn/robotic/overheat/wound_injury(datum/wound/old_wound, attack_direction)
+/datum/wound/burn/robotic/overheat/wound_injury(datum/wound/old_wound, attack_direction)
 	. = ..()
 
 	if (old_wound && old_wound.severity > severity && istype(old_wound, /datum/wound/burn/robotic/overheat))
@@ -132,9 +132,8 @@
 /datum/wound/burn/robotic/overheat/Destroy()
 	QDEL_NULL(mob_glow)
 
-		highest_scar = null
-	return ..()
-
+ highest_scar = null
+ return ..()
 
 /datum/wound/burn/robotic/overheat/set_victim(mob/living/new_victim)
 	if (victim)

--- a/modular_skyrat/modules/medical/code/wounds/synth/robotic_burns.dm
+++ b/modular_skyrat/modules/medical/code/wounds/synth/robotic_burns.dm
@@ -89,14 +89,52 @@
 	/// The glow we have attached to our victim, to simulate our limb glowing.
 	var/obj/effect/dummy/lighting_obj/moblight/mob_glow
 
+	/// A bad system I'm using to track the worst scar we earned (since we can demote, we want the biggest our wound has been, not what it was when it was cured (probably moderate))
+	var/datum/scar/highest_scar
+
 /datum/wound/burn/robotic/overheat/New(temperature)
 	chassis_temperature = (isnull(temperature) ? get_random_starting_temperature() : temperature)
 
 	return ..()
 
+	/datum/wound/burn/robotic/overheat/wound_injury(datum/wound/old_wound, attack_direction)
+	. = ..()
+
+	if (old_wound && old_wound.severity > severity && istype(old_wound, /datum/wound/burn/robotic/overheat))
+		var/datum/wound/burn/robotic/overheat/overheat_wound = old_wound
+		if (overheat_wound.highest_scar)
+			set_highest_scar(overheat_wound.highest_scar)
+			overheat_wound.clear_highest_scar()
+
+	if (!highest_scar && can_scar)
+		var/datum/scar/new_scar = new
+		set_highest_scar(new_scar)
+		new_scar.generate(limb, src, add_to_scars = FALSE)
+
+/datum/wound/burn/robotic/overheat/proc/set_highest_scar(datum/scar/new_scar)
+	if (highest_scar)
+		UnregisterSignal(highest_scar, COMSIG_QDELETING)
+	if (new_scar)
+		RegisterSignal(new_scar, COMSIG_QDELETING, PROC_REF(clear_highest_scar))
+	highest_scar = new_scar
+
+/datum/wound/burn/robotic/overheat/proc/clear_highest_scar(datum/source)
+	SIGNAL_HANDLER
+
+	set_highest_scar(null)
+
+/datum/wound/burn/robotic/overheat/remove_wound(ignore_limb, replaced)
+	if (!replaced && highest_scar)
+		already_scarred = TRUE
+		highest_scar.lazy_attach(limb)
+	return ..()
+
 /datum/wound/burn/robotic/overheat/Destroy()
 	QDEL_NULL(mob_glow)
+
+		highest_scar = null
 	return ..()
+
 
 /datum/wound/burn/robotic/overheat/set_victim(mob/living/new_victim)
 	if (victim)
@@ -219,7 +257,7 @@
 	var/clamped_new_temperature
 	var/heat_adjustment_used
 
-	if(temp_delta > 0)
+	if (temp_delta > 0)
 		clamped_new_temperature = min(min(chassis_temperature + max(temp_delta, 1), temperature), heating_threshold)
 		heat_adjustment_used = (clamped_new_temperature / unclamped_new_temperature)
 	else

--- a/modular_skyrat/modules/medical/code/wounds/synth/robotic_pierce.dm
+++ b/modular_skyrat/modules/medical/code/wounds/synth/robotic_pierce.dm
@@ -41,7 +41,7 @@
 	process_shock_spark_count_max = 1
 	process_shock_spark_count_min = 1
 
-	wirecut_repair_percent = 0.065 // not even faster at this point
+	wirecut_repair_percent = 0.104
 	wire_repair_percent = 0.026
 
 	initial_sparks_amount = 1
@@ -84,7 +84,7 @@
 	process_shock_spark_count_max = 2
 	process_shock_spark_count_min = 1
 
-	wirecut_repair_percent = 0.068
+	wirecut_repair_percent = 0.08
 	wire_repair_percent = 0.02
 
 	initial_sparks_amount = 3
@@ -129,7 +129,7 @@
 	process_shock_spark_count_max = 3
 	process_shock_spark_count_min = 2
 
-	wirecut_repair_percent = 0.067
+	wirecut_repair_percent = 0.072
 	wire_repair_percent = 0.018
 
 	initial_sparks_amount = 8

--- a/modular_skyrat/modules/medical/code/wounds/synth/robotic_slash.dm
+++ b/modular_skyrat/modules/medical/code/wounds/synth/robotic_slash.dm
@@ -220,7 +220,7 @@
 	if (!victim)
 		return seconds_for_intensity
 
-        seconds_for_intensity -= (get_heat_healing() * seconds_per_tick)
+ seconds_for_intensity -= (get_heat_healing() * seconds_per_tick)
 
 	if (seconds_for_intensity > 0 && HAS_TRAIT(victim, TRAIT_COAGULATING))
 		seconds_for_intensity *= ELECTRICAL_DAMAGE_CLOTTING_PROGRESS_MULT

--- a/modular_skyrat/modules/medical/code/wounds/synth/robotic_slash.dm
+++ b/modular_skyrat/modules/medical/code/wounds/synth/robotic_slash.dm
@@ -21,6 +21,9 @@
 /// The maximum burn damage our limb can have before we refuse to let people who havent aggrograbbed the limb repair it with wires. This is so people can opt to just fix the burn damage.
 #define ELECTRICAL_DAMAGE_MAX_BURN_DAMAGE_TO_LET_WIRES_REPAIR 5
 
+/// If progress is positive (not decreasing) after applying ELECTRICAL_DAMAGE_CLOTTING_HEALING_AMOUNT, we multiply it against this.
+#define ELECTRICAL_DAMAGE_CLOTTING_PROGRESS_MULT 0.5
+
 /datum/wound/electrical_damage
 	name = "Electrical (Wires) Wound"
 
@@ -217,7 +220,12 @@
 	if (!victim)
 		return seconds_for_intensity
 
-	return seconds_for_intensity - (get_heat_healing() * seconds_per_tick)
+        seconds_for_intensity -= (get_heat_healing() * seconds_per_tick)
+
+	if (seconds_for_intensity > 0 && HAS_TRAIT(victim, TRAIT_COAGULATING))
+		seconds_for_intensity *= ELECTRICAL_DAMAGE_CLOTTING_PROGRESS_MULT
+
+	return seconds_for_intensity
 
 /// Returns how many deciseconds progress should be reduced by, based on the current heat of our victim's body.
 /datum/wound/electrical_damage/proc/get_heat_healing(do_message = prob(heat_heal_message_chance))
@@ -318,12 +326,12 @@
 	var/change = (processing_full_shock_threshold * wire_repair_percent) * ELECTRICAL_DAMAGE_SUTURE_WIRE_HEALING_AMOUNT_MULT
 	var/delay_mult = 1
 	if (user == victim)
-		delay_mult *= 1.5
+		delay_mult *= 1.4
 	if (is_suture)
-		delay_mult *= 2
+		delay_mult *= 1.5
 		var/obj/item/stack/medical/suture/suture_item = suturing_item
 		var/obj/item/stack/medical/suture/base_suture = /obj/item/stack/medical/suture
-		change += (suture_item.heal_brute - initial(base_suture.heal_brute))
+		change = max(change - (suture_item.heal_brute - initial(base_suture.heal_brute)), 0.00001)
 
 	// as this is the trauma treatment, there are less bonuses
 	// if youre doing this, youre probably doing this on-the-spot
@@ -334,7 +342,7 @@
 	if (HAS_TRAIT(user, TRAIT_DIAGNOSTIC_HUD))
 		delay_mult *= 0.8
 	if (HAS_TRAIT(src, TRAIT_WOUND_SCANNED))
-		change *= 1.2
+		change *= 1.5
 
 	var/their_or_other = (user == victim ? "[user.p_their()]" : "[victim]'s")
 	var/your_or_other = (user == victim ? "your" : "[victim]'s")
@@ -377,17 +385,16 @@
 	var/change = (processing_full_shock_threshold * wirecut_repair_percent)
 	var/delay_mult = 1
 	if (user == victim)
-		delay_mult *= 2.5
+		delay_mult *= 2
 	if (is_retractor)
 		delay_mult *= 2
 		change *= 0.8
 	var/knows_wires = FALSE
 	if (HAS_TRAIT(user, TRAIT_KNOW_ROBO_WIRES))
-		delay_mult *= 0.9
-		change *= 1.7
+		delay_mult *= 0.3
 		knows_wires = TRUE
 	else if (HAS_TRAIT(user, TRAIT_KNOW_ENGI_WIRES))
-		change *= 1.35
+		delay_mult *= 0.6
 		knows_wires = TRUE
 	if (HAS_TRAIT(user, TRAIT_DIAGNOSTIC_HUD))
 		if (knows_wires)
@@ -395,7 +402,7 @@
 		else
 			delay_mult *= 0.75
 	if (HAS_TRAIT(src, TRAIT_WOUND_SCANNED))
-		delay_mult *= 0.8
+		change *= 1.5
 
 	var/their_or_other = (user == victim ? "[user.p_their()]" : "[victim]'s")
 	var/your_or_other = (user == victim ? "your" : "[victim]'s")
@@ -510,7 +517,7 @@
 	process_shock_spark_count_max = 1
 	process_shock_spark_count_min = 1
 
-	wirecut_repair_percent = 0.085 // not even faster at this point
+	wirecut_repair_percent = 0.14
 	wire_repair_percent = 0.035
 
 	initial_sparks_amount = 1
@@ -553,7 +560,7 @@
 	process_shock_spark_count_max = 2
 	process_shock_spark_count_min = 1
 
-	wirecut_repair_percent = 0.1
+	wirecut_repair_percent = 0.128
 	wire_repair_percent = 0.032
 
 	initial_sparks_amount = 3
@@ -626,3 +633,5 @@
 #undef ELECTRICAL_DAMAGE_MAX_BURN_DAMAGE_TO_LET_WIRES_REPAIR
 #undef ELECTRICAL_DAMAGE_POWER_PER_TICK_MULT
 #undef ELECTRICAL_DAMAGE_SUTURE_WIRE_HEALING_AMOUNT_MULT
+
+#undef ELECTRICAL_DAMAGE_CLOTTING_PROGRESS_MULT

--- a/strings/wounds/metal_scar_desc.json
+++ b/strings/wounds/metal_scar_desc.json
@@ -7,7 +7,7 @@
 
 	"bluntsevere": [
 		"an area of slightly crumpled metal",
-		"some faded cracks on some screws"
+		"some misaligned plates"
 	],
 
 	"bluntcritical": [
@@ -21,13 +21,13 @@
 	],
 
 	"slashsevere": [
-		"a pair of soldered, straight cracks",
-		"an area of freshly replaced metal",
-        "has some deep welded scratches on the metal"
+		"a pair of soldered cracks",
+		"an line of freshly replaced metal",
+        "some deep welds on the metal"
 	],
 
 	"slashcritical": [
-		"a matrix of desperately soldered wide cracks",
+		"a matrix of desperately soldered cracks",
 		"some gruesome welding lines",
 		"a series of deep and wide welded gashes"
 	],
@@ -38,13 +38,13 @@
 	],
 
 	"piercesevere": [
-		"a wad of hardened solder",
-		"a small patch of fresh metal in a small hole"
+		"a large wad of hardened solder",
+		"a few cracks originating from a small hole"
 	],
 
 	"piercecritical": [
 		"a large splot of hardened solder",
-		"an inward caving hole leading to fresh metal"
+		"a spiderweb of cracks crawling from a sealed hole"
 	],
 
 	"burnsevere": [
@@ -54,14 +54,14 @@
 	],
 
 	"burncritical": [
-		"lots of polychromatic metal on it",
-		"some heat-warped plating",
-		"melting marks"
+		"streaks of polychromatic metal",
+		"gruesomely heat-warped plating",
+		"huge melting marks"
 	],
 
 	"dismember": [
-		"has some fresh metal around various joints",
+		"has fresh metal around various joints",
 		"has some solder marks securing various joints",
-		"has clear re-seating welding marks"
+		"has clear re-seating marks"
 	]
 }

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7414,6 +7414,7 @@
 #include "modular_skyrat\modules\medical\code\wounds\medical.dm"
 #include "modular_skyrat\modules\medical\code\wounds\muscle.dm"
 #include "modular_skyrat\modules\medical\code\wounds\wound_effects.dm"
+#include "modular_skyrat\modules\medical\code\wounds\synth\medicine_reagents.dm"
 #include "modular_skyrat\modules\medical\code\wounds\synth\robotic_burns.dm"
 #include "modular_skyrat\modules\medical\code\wounds\synth\robotic_muscle.dm"
 #include "modular_skyrat\modules\medical\code\wounds\synth\robotic_pierce.dm"


### PR DESCRIPTION

## About The Pull Request

Mirrored four synth wound PRs from Skyrat:
New reagent to cool synth burns
Coagulants treat synth electrical damage
Synth wound rewrite, burns now apply scars
Various nerfs, tweaks & fixes to synth wounds

## Why It's Good For The Game

Requested port, synth changes.

## Changelog

:cl: Koltsov
add: Dinitrogen Plasmide, treats synthetic burns
balance: Coagulants treat electrical damage for synths
fix: Synth burn wounds properly apply scars
spellcheck: Some synth wounds rewritten
fix: Synth wound oscillations will no longer cause you to reel from impacts if there were none
balance: Synth blunt wounds are now faster to treat
balance: Wirecutters on electrical damage always fix 4x more than suturing
balance: Synth wound oscillations now have a minimum of 3 seconds between each oscillation
/:cl:
