### PR TITLE
Roboticist Pamphlet Port

### DIFF
--- a/modular_zubbers/code/modules/jobs/job_types/roboticist.dm
+++ b/modular_zubbers/code/modules/jobs/job_types/roboticist.dm
@@ -1,0 +1,14 @@
+/datum/outfit/job/roboticist/New()
+	. = ..()
+
+	LAZYINITLIST(backpack_contents)
+	backpack_contents[/obj/item/paper/pamphlet/roboticist_reminder] = 1
+
+/obj/item/paper/pamphlet/roboticist_reminder
+	name = "pamphlet - 'Reminder of roboticist duties'"
+	default_raw_text = "Don't forget that your duties include treating the synthetic lifeforms aboard the station! Heres some tips and tricks to get you started... \n\
+	You can buy <b>health analyzers</b> from your vendor, as well as <b>burn wound treatment chems</b>! Generally, you'll be using the coolant bottles. \n\
+	Make sure to <b>use the health analyzers in hand</b> to activate <b>wound mode</b> if you're ever confused about a wound! <b>Blunt wounds</b> even show \
+	the current treatment step!\n\
+	Your <b>departmental order console</b> includes things like synthetic medicine crates!\n\
+	<b>Epipens</b> are an effective treatment method for synthetic slash/pierce wounds!"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8300,6 +8300,7 @@
 #include "modular_zubbers\code\modules\jobs\job_types\clown.dm"
 #include "modular_zubbers\code\modules\jobs\job_types\curator.dm"
 #include "modular_zubbers\code\modules\jobs\job_types\nanotrasen_consultant.dm"
+#include "modular_zubbers\code\modules\jobs\job_types\roboticist.dm"
 #include "modular_zubbers\code\modules\languages\vampiric.dm"
 #include "modular_zubbers\code\modules\lewd_machinery\lustwish.dm"
 #include "modular_zubbers\code\modules\liquids\height_floors.dm"


### PR DESCRIPTION
## About The Pull Request

Added pamphlet to roboticist starting gear, detailing how to tend to the new synth wounds.
PR Has been tested, game compiles and runs, pamphlet is present in backpack.

## Why It's Good For The Game

Requested port, roboticist loadout kit addition

## Changelog

:cl: Koltsov
add: Pamphlet to starting roboticist equipment, brief explanation of synth wounds and their treatment
/:cl:
