### PR TITLE
Transhuman Quirk Port

### DIFF
--- a/code/_globalvars/lists/quirks.dm
+++ b/code/_globalvars/lists/quirks.dm
@@ -20,9 +20,11 @@ GLOBAL_LIST_INIT(limb_choice, list(
 	"Right Leg" = /obj/item/bodypart/leg/right/robot/surplus,
 ))
 
-GLOBAL_LIST_INIT(limb_choice_transhuman, list(
+GLOBAL_LIST_INIT(part_choice_transhuman, list(
 	"Left Arm" = /obj/item/bodypart/arm/left/robot,
 	"Right Arm" = /obj/item/bodypart/arm/right/robot,
 	"Left Leg" = /obj/item/bodypart/leg/left/robot,
 	"Right Leg" = /obj/item/bodypart/leg/right/robot,
+	"Robotic Voice Box" = /obj/item/organ/internal/tongue/robot,
+	"Flashlights for Eyes" = /obj/item/organ/internal/eyes/robotic/flashlight,
 ))

--- a/code/datums/quirks/neutral_quirks/transhumanist.dm
+++ b/code/datums/quirks/neutral_quirks/transhumanist.dm
@@ -15,7 +15,7 @@
 
 /datum/quirk/transhumanist
 	name = "Transhumanist"
-	desc = "You see silicon life as the perfect lifeform and despise organic flesh. You are happier around silicons, but get frustrated when around organics. You seek to replace your fleshy limbs with their silicon counterparts. You start with a robotic limb."
+	desc = "You see silicon life as the perfect lifeform and despise organic flesh. You are happier around silicons, but get frustrated when around organics. You seek to replace your failing flesh with perfect silicon. You start with a robotic augmention."
 	icon = FA_ICON_ROBOT
 	quirk_flags = QUIRK_HUMAN_ONLY|QUIRK_PROCESSES|QUIRK_MOODLET_BASED
 	value = 0
@@ -29,7 +29,7 @@
 		/obj/item/toy/figure/borg,
 	)
 	var/slot_string
-	var/obj/item/bodypart/old_limb
+	var/obj/item/old_part
 
 /datum/quirk/transhumanist/add(client/client_source)
 	RegisterSignal(quirk_holder, COMSIG_CARBON_POST_ATTACH_LIMB, PROC_REF(calculate_bodypart_score))
@@ -95,27 +95,54 @@
 		if(-INFINITY to 0)
 			quirk_holder.add_mood_event(MOOD_CATEGORY_TRANSHUMANIST_BODYPART, /datum/mood_event/very_organic)
 
+/datum/quirk_constant_data/transhumanist
+	associated_typepath = /datum/quirk/transhumanist
+	customization_options = list(/datum/preference/choiced/trans_prosthetic)
 
 /datum/quirk/transhumanist/add_unique(client/client_source)
-	var/limb_type = GLOB.limb_choice_transhuman[client_source?.prefs?.read_preference(/datum/preference/choiced/prosthetic)]
-	if(isnull(limb_type))  //Client gone or they chose a random prosthetic
-		limb_type = GLOB.limb_choice_transhuman[pick(GLOB.limb_choice_transhuman)]
+	var/part_type = GLOB.part_choice_transhuman[client_source?.prefs?.read_preference(/datum/preference/choiced/prosthetic)]
+	if(isnull(part_type))  //Client gone or they chose a random part
+		part_type = GLOB.part_choice_transhuman[pick(GLOB.part_choice_transhuman)]
 
 	var/mob/living/carbon/human/human_holder = quirk_holder
-	var/obj/item/bodypart/new_part = new limb_type()
-
-	slot_string = "[new_part.plaintext_zone]"
-	old_limb = human_holder.return_and_replace_bodypart(new_part, special = TRUE)
+    var/obj/item/new_part = new part_type()
+	if(isbodypart(new_part))
+		var/obj/item/bodypart/new_bodypart = new_part
+		slot_string = "[new_bodypart.plaintext_zone]"
+		old_part = human_holder.return_and_replace_bodypart(new_bodypart, special = TRUE)
+	else if(isorgan(new_part))
+		var/obj/item/organ/new_organ = new_part
+		old_part = human_holder.get_organ_slot(new_organ.slot)
+		if(new_organ.Insert(human_holder, special = TRUE))
+			old_part.moveToNullspace()
+			STOP_PROCESSING(SSobj, old_part)
+			slot_string = "[new_organ.name]"
 
 /datum/quirk/transhumanist/post_add()
 	if(slot_string)
-		to_chat(quirk_holder, span_boldannounce("Your [slot_string] has been replaced with a robot arm. You need to use a welding tool and cables to repair it, instead of sutures and regenerative meshes."))
+		if(isbodypart(old_part))
+			to_chat(quirk_holder, span_boldannounce("Your [slot_string] has been replaced with a robotic limb. You need to use a welding tool and cables to repair it, instead of sutures and regenerative meshes."))
+		else if (old_part.name == "eyes")
+			to_chat(quirk_holder, span_boldannounce("You replaced your eyes with flashlights, not cameras. You can't see a thing!"))
+		else if (isorgan(old_part))
+			to_chat(quirk_holder, span_boldannounce("Your [slot_string] brings you one step closer to silicon perfection, but you feel you're not quite there yet."))
 
 /datum/quirk/transhumanist/remove()
-	if(old_limb)
+	if(old_part)
 		var/mob/living/carbon/human/human_holder = quirk_holder
-		human_holder.del_and_replace_bodypart(old_limb, special = TRUE)
-		old_limb = null
+		if(isbodypart(old_part))
+			var/obj/item/bodypart/old_bodypart = old_part
+			human_holder.del_and_replace_bodypart(old_bodypart, special = TRUE)
+			old_bodypart = null
+		else if(isorgan(old_part))
+			var/obj/item/organ/old_organ = old_part
+			old_part = human_holder.get_organ_slot(ORGAN_SLOT_TONGUE)
+			old_organ.Insert(quirk_holder, special = TRUE)
+			old_part.moveToNullspace()
+			STOP_PROCESSING(SSobj, old_part)
+			old_organ = null
+			old_part = null
+
 	quirk_holder.clear_mood_event(MOOD_CATEGORY_TRANSHUMANIST_BODYPART)
 	quirk_holder.clear_mood_event(MOOD_CATEGORY_TRANSHUMANIST_PEOPLE)
 

--- a/code/datums/quirks/neutral_quirks/transhumanist.dm
+++ b/code/datums/quirks/neutral_quirks/transhumanist.dm
@@ -105,7 +105,7 @@
 		part_type = GLOB.part_choice_transhuman[pick(GLOB.part_choice_transhuman)]
 
 	var/mob/living/carbon/human/human_holder = quirk_holder
-    var/obj/item/new_part = new part_type()
+	var/obj/item/new_part = new part_type()
 	if(isbodypart(new_part))
 		var/obj/item/bodypart/new_bodypart = new_part
 		slot_string = "[new_bodypart.plaintext_zone]"

--- a/code/modules/client/preferences/trans_prosthetic.dm
+++ b/code/modules/client/preferences/trans_prosthetic.dm
@@ -1,0 +1,17 @@
+/datum/preference/choiced/trans_prosthetic
+	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
+	savefile_key = "trans_prosthetic"
+	savefile_identifier = PREFERENCE_CHARACTER
+
+/datum/preference/choiced/trans_prosthetic/init_possible_values()
+	return list("Random") + GLOB.part_choice_transhuman
+
+/datum/preference/choiced/trans_prosthetic/is_accessible(datum/preferences/preferences)
+	. = ..()
+	if (!.)
+		return FALSE
+
+	return "Transhumanist" in preferences.all_quirks
+
+/datum/preference/choiced/trans_prosthetic/apply_to_human(mob/living/carbon/human/target, value)
+	return

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3693,6 +3693,7 @@
 #include "code\modules\client\preferences\statpanel.dm"
 #include "code\modules\client\preferences\tgui.dm"
 #include "code\modules\client\preferences\tooltips.dm"
+#include "code\modules\client\preferences\trans_prosthetic.dm"
 #include "code\modules\client\preferences\ui_style.dm"
 #include "code\modules\client\preferences\underwear_color.dm"
 #include "code\modules\client\preferences\uplink_location.dm"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/trans_prosthetic.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/trans_prosthetic.tsx
@@ -1,0 +1,6 @@
+import { FeatureChoiced, FeatureDropdownInput } from '../base';
+
+export const trans_prosthetic: FeatureChoiced = {
+  name: 'Augment',
+  component: FeatureDropdownInput,
+};


### PR DESCRIPTION
## About The Pull Request

New options of synthetic organs for the transhuman quirk
Tgui addition to allow selection of the bodypart when picking transhuman quirk
PR Tested, game compiles and runs, menu is present in quirk settings

## Why It's Good For The Game

Requested port, transhuman changes

## Changelog

:cl: Koltsov
add: Transhumanist quirk allows selection of augmentation in menu.
add: Transhumanist quirk can now provide a robotic voice box, or flashlight eyes.
spellcheck: Transhumanist's roundstart text fixed.
/:cl:
