### PR TITLE
Cook and Bartender Job Removal

### DIFF
--- a/code/modules/jobs/job_types/bartender.dm
+++ b/code/modules/jobs/job_types/bartender.dm
@@ -1,3 +1,4 @@
+/* JOB REMOVAL START
 /datum/job/bartender
 	title = JOB_BARTENDER
 	description = "Serve booze, mix drinks, keep the crew drunk."
@@ -66,3 +67,4 @@
 	if(H.age < AGE_MINOR)
 		W.registered_age = AGE_MINOR
 		to_chat(H, span_notice("You're not technically old enough to access or serve alcohol, but your ID has been discreetly modified to display your age as [AGE_MINOR]. Try to keep that a secret!"))
+JOB REMOVAL END */

--- a/code/modules/jobs/job_types/cargo_technician.dm
+++ b/code/modules/jobs/job_types/cargo_technician.dm
@@ -5,8 +5,8 @@
 		ship bounty cubes."
 	department_head = list(JOB_QUARTERMASTER)
 	faction = FACTION_STATION
-	total_positions = 5
-	spawn_positions = 3
+	total_positions = 4
+	spawn_positions = 4
 	supervisors = SUPERVISOR_QM
 	exp_granted_type = EXP_TYPE_CREW
 	config_tag = "CARGO_TECHNICIAN"

--- a/code/modules/jobs/job_types/cook.dm
+++ b/code/modules/jobs/job_types/cook.dm
@@ -1,3 +1,4 @@
+/* JOB REMOVAL START
 /datum/job/cook
 	title = JOB_COOK
 	description = "Serve food, cook meat, keep the crew fed."
@@ -92,3 +93,4 @@
 	. = ..()
 	. += /obj/item/clothing/suit/apron/chef
 	. += /obj/item/clothing/head/soft/mime
+JOB REMOVAL END */

--- a/code/modules/mob_spawn/corpses/job_corpses.dm
+++ b/code/modules/mob_spawn/corpses/job_corpses.dm
@@ -8,7 +8,7 @@
 
 /obj/effect/mob_spawn/corpse/human/cook
 	name = JOB_COOK
-	outfit = /datum/outfit/job/cook
+	outfit = /datum/outfit/job/assistant
 	icon_state = "corpsecook"
 
 /obj/effect/mob_spawn/corpse/human/doctor

--- a/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -124,6 +124,18 @@
 		"Mailman",
 		"Receiving Clerk",
 		"Union Associate",
+	    "Bartender",
+		"Barista",
+		"Barkeeper",
+		"Mixologist",
+		"Cook",
+		"Butcher",
+		"Chef",
+		"Culinary Artist",
+		"Sous-Chef",
+		"Baker",
+		"Confectionist",
+		"Pastry Chef",
 	)
 
 /datum/job/chaplain


### PR DESCRIPTION
## About The Pull Request

Requested PR, removes Cook and Bartender Jobs
Adds Cook and Bartender alt titles to Cargo Tech Job
Lowered Cargo Tech Job slots to 4

## Why It's Good For The Game

Requested change.

## Changelog

:cl: Koltsov
del: Removed Cook Job
del: Removed Bartender Job
add: Adds Cook and Bartender alt titles to Cargo Tech Job
/:cl: