### PR TITLE
Changes Barber and Curator to No Department

### DIFF
--- a/code/modules/jobs/job_types/curator.dm
+++ b/code/modules/jobs/job_types/curator.dm
@@ -14,7 +14,7 @@
 	plasmaman_outfit = /datum/outfit/plasmaman/curator
 
 	paycheck = PAYCHECK_CREW
-	paycheck_department = ACCOUNT_SRV
+	paycheck_department = ACCOUNT_CIV
 
 	mind_traits = list(TRAIT_TOWER_OF_BABEL)
 

--- a/code/modules/jobs/job_types/curator.dm
+++ b/code/modules/jobs/job_types/curator.dm
@@ -19,9 +19,6 @@
 	mind_traits = list(TRAIT_TOWER_OF_BABEL)
 
 	display_order = JOB_DISPLAY_ORDER_CURATOR
-	departments_list = list(
-		/datum/job_department/service,
-		)
 
 	mail_goodies = list(
 		/obj/item/book/random = 44,

--- a/modular_skyrat/modules/salon/code/barber.dm
+++ b/modular_skyrat/modules/salon/code/barber.dm
@@ -16,9 +16,6 @@
 	paycheck_department = ACCOUNT_SRV
 	display_order = JOB_DISPLAY_ORDER_BARTENDER
 	bounty_types = CIV_JOB_BASIC
-	departments_list = list(
-		/datum/job_department/service,
-		)
 
 	family_heirlooms = list(/obj/item/hairbrush/comb, /obj/item/razor)
 	job_flags = JOB_ANNOUNCE_ARRIVAL | JOB_CREW_MANIFEST | JOB_EQUIP_RANK | JOB_CREW_MEMBER | JOB_NEW_PLAYER_JOINABLE | JOB_REOPEN_ON_ROUNDSTART_LOSS | JOB_ASSIGN_QUIRKS | JOB_CAN_BE_INTERN

--- a/modular_skyrat/modules/salon/code/barber.dm
+++ b/modular_skyrat/modules/salon/code/barber.dm
@@ -13,7 +13,7 @@
 	plasmaman_outfit = /datum/outfit/plasmaman
 
 	paycheck = PAYCHECK_CREW
-	paycheck_department = ACCOUNT_SRV
+	paycheck_department = ACCOUNT_CIV
 	display_order = JOB_DISPLAY_ORDER_BARTENDER
 	bounty_types = CIV_JOB_BASIC
 


### PR DESCRIPTION
## About The Pull Request

Requested PR, Barber and Curator now match Assistant as having no specific department.

## Why It's Good For The Game

Requested change.

## Changelog

:cl: Koltsov
bal: Removed Barbers Job association with a specific department
bal: Removed Curator Job association with a specific department
/:cl: