### PR TITLE
Changes Roboticist to Engineering Department

### DIFF
--- a/code/modules/jobs/job_types/roboticist.dm
+++ b/code/modules/jobs/job_types/roboticist.dm
@@ -15,7 +15,7 @@
 	outfit = /datum/outfit/job/roboticist
 	plasmaman_outfit = /datum/outfit/plasmaman/robotics
 	departments_list = list(
-		/datum/job_department/science,
+		/datum/job_department/engineering,
 		)
 
 	paycheck = PAYCHECK_CREW

--- a/code/modules/jobs/job_types/roboticist.dm
+++ b/code/modules/jobs/job_types/roboticist.dm
@@ -19,7 +19,7 @@
 		)
 
 	paycheck = PAYCHECK_CREW
-	paycheck_department = ACCOUNT_SCI
+	paycheck_department = ACCOUNT_ENG
 
 	display_order = JOB_DISPLAY_ORDER_ROBOTICIST
 


### PR DESCRIPTION
## About The Pull Request

Requested PR, Roboticist is now under Engineering rather than Science Department

## Why It's Good For The Game

Requested change.

## Changelog

:cl: Koltsov
bal: Changed Roboticist to Engineering Department
/:cl:
